### PR TITLE
[Refactor] use `hasown` for robustness

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 
-var hasOwnProperty = Object.prototype.hasOwnProperty;
+var has = require('hasown');
 
 module.exports = exports = function hasOwn(prop, obj) {
-  return hasOwnProperty.call(obj, prop);
+  return has(obj, prop);
 }
 
 exports.version = require('./package.json').version;

--- a/package-lock.json
+++ b/package-lock.json
@@ -299,6 +299,21 @@
       "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
       "dev": true
     },
+    "hasown": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
+      "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
+      "requires": {
+        "function-bind": "^1.1.2"
+      },
+      "dependencies": {
+        "function-bind": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+          "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
+        }
+      }
+    },
     "he": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -15,5 +15,8 @@
   "homepage": "https://github.com/aheckmann/has-own/",
   "devDependencies": {
     "mocha": "^6.2.2"
+  },
+  "dependencies": {
+    "hasown": "^2.0.0"
   }
 }


### PR DESCRIPTION
Not sure if you're interested, but this will make your package robust against later deletion of `Function.prototype.call`.